### PR TITLE
make adapter options overwritable if QC is used as a subworkflow

### DIFF
--- a/tests/integration/single_end_zipped_contaminations.json
+++ b/tests/integration/single_end_zipped_contaminations.json
@@ -1,7 +1,7 @@
 {
   "QC.read1": "tests/data/ct_r1.fq.gz",
-  "QC.adapters": null,
-  "QC.contaminations": [
+  "QC.Cutadapt.adapterBoth": null,
+  "QC.Cutadapt.contaminations": [
     "GATCGGAAGAGCACACGTCTGAACTCCAGTCACGTCCGCATCTCGTATGCCGTCTTCTGCTTG",
     "GATCGGAAGAGCACACGTCTGAACTCCAGTCACATCACGATCTCGTATGCCGTCTTCTGCTTG"
   ]


### PR DESCRIPTION
Also updated cutadapt to newest version.